### PR TITLE
Cb 1100 did resolver test async

### DIFF
--- a/packages/resolver/src/index.js
+++ b/packages/resolver/src/index.js
@@ -1,5 +1,6 @@
 const networks = require('../networks.json')
-const Storage = require('@lorena/storage')
+// const Storage = require('@lorena/storage')
+const Comms = require('@lorena/comms')
 const Blockchain = require('@lorena/blockchain-substrate')
 const bip39 = require('bip39')
 var debug = require('debug')('did-resolver:debug')
@@ -50,8 +51,10 @@ function getResolver () {
     }
 
     // Connect to Matrix to get the DID Document
-    const storage = await new Storage(info.matrixEndpoint)
-    const didDoc = await storage.get(didDocHash)
+    const comms = new Comms(info.matrixEndpoint)
+    // ToDo Use Storage or Comms depending on the Hash type
+    // const storage = new Storage(info.matrixEndpoint)
+    const didDoc = await comms.downloadFile(didDocHash)
 
     // no DID Document found: return nothing
     if (!didDoc || !didDoc.data) {

--- a/packages/resolver/src/index.js
+++ b/packages/resolver/src/index.js
@@ -1,5 +1,6 @@
 const networks = require('../networks.json')
-// const Storage = require('@lorena/storage')
+const CID = require('cids')
+const Storage = require('@lorena/storage')
 const Comms = require('@lorena/comms')
 const Blockchain = require('@lorena/blockchain-substrate')
 const bip39 = require('bip39')
@@ -50,11 +51,17 @@ function getResolver () {
       return null
     }
 
-    // Connect to Matrix to get the DID Document
-    const comms = new Comms(info.matrixEndpoint)
-    // ToDo Use Storage or Comms depending on the Hash type
-    // const storage = new Storage(info.matrixEndpoint)
-    const didDoc = await comms.downloadFile(didDocHash)
+    // Get the diddoc
+    let didDoc
+    // if it's a ContentID, use the storage mechanism (IPFS)
+    if (CID.isCID(didDocHash)) {
+      const storage = new Storage(info.ipfsEndpoint)
+      didDoc = await storage.get(didDocHash)
+    } else {
+      // otherwise use Matrix storage
+      const comms = new Comms(info.matrixEndpoint)
+      didDoc = await comms.downloadFile(didDocHash)
+    }
 
     // no DID Document found: return nothing
     if (!didDoc || !didDoc.data) {

--- a/packages/resolver/src/index.test.js
+++ b/packages/resolver/src/index.test.js
@@ -52,6 +52,7 @@ for (const did of badDIDs) {
 const goodDIDs = [
   'did:lor:labdev:WjBSUVNIRjJhRFJoYjJsMU0wSnVka0Zz',
   'did:lor:labtest:TjFkVWNrbFFjMmRDUVhsYU9YWlZVbTA1'
+  // TODO: Add a DID which has its DIDDOC stored in IPFS
 ]
 
 for (const did of goodDIDs) {

--- a/packages/resolver/src/index.test.js
+++ b/packages/resolver/src/index.test.js
@@ -35,54 +35,45 @@ test('should construct the resolver', () => {
   expect(resolver.resolve).toBeDefined()
 })
 
-test('should get an empty public key for a nonexistent DID', async () => {
-  await badDIDs.forEach(async (did) => {
+for (const did of badDIDs) {
+  test('should get an empty public key for a nonexistent DID', async () => {
     // using a valid DID, retrieve public key
     const publicKey = await LorenaDidResolver.getPublicKeyForDid(did)
     expect(publicKey).toBe('')
   })
-})
 
-test('should get nothing for a nonexistent DID', async () => {
-  await badDIDs.forEach(async (did) => {
+  test('should get nothing for a nonexistent DID', async () => {
     // using a invalid DID, empty did doc
     const doc = await resolver.resolve(did)
     expect(doc).toBeNull()
   })
-})
+}
 
 const goodDIDs = [
   'did:lor:labdev:WjBSUVNIRjJhRFJoYjJsMU0wSnVka0Zz',
-  'did:lor:labtest:VFhKQ2FsazVSM1pWY0VaWmJXVlpSVmRS'
+  'did:lor:labtest:TjFkVWNrbFFjMmRDUVhsYU9YWlZVbTA1'
 ]
 
-test('should get the public key for a DID', async () => {
-  await goodDIDs.forEach(async (did) => {
+for (const did of goodDIDs) {
+  test('should get the public key for a DID', async () => {
     jest.setTimeout(10000)
     // using a valid DID, retrieve public key
     const publicKey = await LorenaDidResolver.getPublicKeyForDid(did)
     expect(publicKey).toBeDefined()
   })
-})
 
-test.skip('should get the complete DID Document for a DID', async () => {
-  jest.setTimeout(30000)
-  console.log('111111111111111')
-  await goodDIDs.forEach(async (did) => {
-    console.log('2222222222222222')
-    console.log('33333333333 - did: ', did)
+  test('should get the complete DID Document for a DID', async () => {
+    jest.setTimeout(50000)
     // using a valid DID, retrieve public key
     const doc = await resolver.resolve(did)
-    console.log('44444444444 - doc: ', doc)
     expect(doc).toBeDefined()
     expect(doc.id).toEqual(did)
-    expect(doc.authentication[0].id).to.contain(did)
+    expect(doc.authentication[0].id).toMatch(new RegExp(did))
     // the public key should be the same as the one in the blockchain
-    // expect(doc.authentication[0].publicKey).toEqual(publicKey)
-    // console.log('DOCCCCCCCCCCCCCCCCCC', doc.authentication[0].publicKey)
-    // console.log(publicKey)
+    const publicKey = await LorenaDidResolver.getPublicKeyForDid(did)
+    expect(doc.authentication[0].publicKey).toEqual(publicKey)
   })
-})
+}
 
 test.skip('should get the fragment for a DID path', async () => {
   const did = 'did:lor:labdev:Wldvd1pqVmZWbEoxYVdaWFdGOW5ja05I/service/0#serviceEndpoint'


### PR DESCRIPTION
Fix resolver and tests

Note: test still not present for retrieving DID Document from IPFS, as the idspace does not yet create identities that way.